### PR TITLE
Enhance test UI

### DIFF
--- a/test_frontend/index.html
+++ b/test_frontend/index.html
@@ -6,16 +6,93 @@
     <title>Chat with LLM Backend</title>
     <script src="https://cdn.socket.io/4.0.0/socket.io.min.js"></script>
     <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        input[type="text"], button { padding: 8px; margin-bottom: 10px; }
-        #messages { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: scroll; }
-        .message { margin-bottom: 5px; }
-        .system-message { color: blue; }
-        .llm-message { color: green; }
-        .user-message { color: black; }
+        body {
+            font-family: Arial, sans-serif;
+            background: #f5f5f5;
+            display: flex;
+            justify-content: center;
+            padding: 20px;
+        }
+
+        #app-container {
+            background: #ffffff;
+            width: 100%;
+            max-width: 800px;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        input[type="text"], button {
+            padding: 8px;
+            margin-bottom: 10px;
+            border-radius: 4px;
+            border: 1px solid #ccc;
+        }
+
+        button {
+            cursor: pointer;
+            background: #0070f3;
+            color: #fff;
+            border: none;
+        }
+
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+
+        #messages {
+            border: 1px solid #ccc;
+            padding: 10px;
+            height: 400px;
+            overflow-y: auto;
+            background: #fafafa;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .message {
+            margin-bottom: 10px;
+            padding: 8px 12px;
+            border-radius: 8px;
+            max-width: 80%;
+            word-wrap: break-word;
+        }
+
+        .system-message {
+            background: #eee;
+            color: #333;
+            font-style: italic;
+            align-self: center;
+        }
+
+        .llm-message {
+            background: #e8ffe7;
+            color: #0b6623;
+            align-self: flex-start;
+        }
+
+        .user-message {
+            background: #e7f3ff;
+            color: #000;
+            align-self: flex-end;
+            text-align: right;
+        }
+
+        #message-input-container {
+            display: flex;
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        #messageInput {
+            flex: 1;
+        }
     </style>
 </head>
 <body>
+<div id="app-container">
     <h1>Chat with LLM Backend</h1>
 
     <div id="connection-status">
@@ -63,8 +140,10 @@
     <div id="chat-interface" style="display: none;">
         <h3>Messages</h3>
         <div id="messages"></div>
-        <input type="text" id="messageInput" placeholder="Type a message (e.g., @MyGPT What is the weather? or #share New context)" style="width: 80%;">
-        <button onclick="sendMessage()">Send</button>
+        <div id="message-input-container">
+            <input type="text" id="messageInput" placeholder="Type a message (e.g., @MyGPT What is the weather? or #share New context)">
+            <button onclick="sendMessage()">Send</button>
+        </div>
     </div>
 
     <script>
@@ -266,6 +345,7 @@
             messagesDiv.appendChild(messageElement);
             messagesDiv.scrollTop = messagesDiv.scrollHeight; // Auto-scroll to bottom
         }
-    </script>
+</script>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize `test_frontend/index.html` styling
- wrap content in an app container
- add input row layout and message bubble styles

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` in `frontend` (fails: `next: not found`)


------
https://chatgpt.com/codex/tasks/task_e_683f8ab0a21883248edb4d17feb56c80